### PR TITLE
Add copy paste response boxes

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -36,3 +36,68 @@
     transform: rotate(360deg);
   }
 }
+
+.sidebar {
+  display: flex;
+  flex-direction: column; /* Ensure column layout */
+  justify-content: flex-start;
+  /* align-items: center; Center content horizontally */
+  text-align: center;
+  margin: 0;
+  top: 0;
+  padding: 2px;
+  width: 25%;
+  background-color: #f1f1f1;
+  position: fixed;
+  height: 100%;
+  overflow: auto;
+}
+
+.sidebar div {
+  color: black;
+  padding: 0; 
+  text-decoration: none;
+  width: 99%;
+}
+ 
+/* .sidebar div.active {
+  background-color: #04AA6D;
+  color: white;
+}
+
+.sidebar div:hover:not(.active) {
+  background-color: #555;
+  color: white;
+} */
+
+div.content {
+  margin-left: 30%;
+  /* padding: 1px 16px; */
+  height: 100vh;
+  /* max-width: fit-content;
+  margin-left: auto;
+  margin-right: auto; */
+  width: 55%;
+}
+
+@media screen and (max-width: 700px) {
+  .sidebar {
+    width: 100%;
+    height: auto;
+    position: relative;
+  }
+  .sidebar div {float: left;}
+  div.content {margin-left: 0;}
+  div.content {width: 100%;}
+}
+
+@media screen and (max-width: 400px) {
+  .sidebar div {
+    top: 0;
+    text-align: center;
+    float: none;
+    justify-content: center;
+    justify-items: center;
+  }
+}
+

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import QuestionPanel from "./QuestionPanel";
 import { Container, Typography, Button, Box, LinearProgress, TextField } from "@mui/material";
 import questionsData from "./tasks.json";
+import './App.css';
 
 const App = () => {
   const [questions, setQuestions] = useState([]);
@@ -89,7 +90,9 @@ const App = () => {
           height: "100vh",
         }}
       >
-        <Typography variant="h4" sx={{ marginBottom: "3vh" }}>
+        <Typography variant="h4" 
+        sx={{ marginBottom: "3vh" }}
+        >
           Thank you for completing the survey!
         </Typography>
         <Button variant="contained" color="primary" onClick={downloadAnswers}>
@@ -102,164 +105,163 @@ const App = () => {
   const progress = ((currentIndex + 1) / questions.length) * 100;
 
   return (
-    <Container
-      maxWidth="lg"
-      sx={{ display: "flex", flexDirection: "column", alignItems: "center", height: "100vh" }}
-    >
-      {/* Centered Question Panel */}
-      <Box sx={{ width: "75%", marginBottom: "5vh" }}>
-        <QuestionPanel
-          query={questions[currentIndex].query}
-          context={questions[currentIndex].context}
-          response={questions[currentIndex].response}
-        />
-      </Box>
-
-      {/* Task Evaluation Box */}
-      <Box
-        sx={{
-          position: "fixed",
-          // top: "50%",
-          right: "0%",
-          // transform: "translateY(-50%)",
-          width: "25%",
-          backgroundColor: "#ffffff",
-          border: "0.5vh solid #f9f9f9",
-          borderRadius: "1px",
-          // backgroundColor: "#f9f9f9",
-          padding: "2vh",
-          boxSizing: "border-box",
-          boxShadow: "0px 1px 2px rgba(0, 0, 0, 0.1)",
-          margin: "0px",
-          textAlign: "center", // Center title and content
-        }}
-      >
-        <Typography variant="h6" sx={{ fontWeight: "bold", marginBottom: "2vh" }}>
-          Task Evaluation
-        </Typography>
-
-        {/* True/False Buttons for Faithfulness */}
-        <Typography variant="body1" sx={{ marginBottom: "10px" }}>
-          Do you think the response is faithful?
-        </Typography>
+    <body>
+    <div class="sidebar">
+      {/* Task Evaluation Sidebar */}
         <Box
           sx={{
-            display: "flex",
-            justifyContent: "center", // Center buttons
-            gap: "10px",
-            marginBottom: "10px",
+            backgroundColor: "#ffffff",
+            padding: "20px",
+            border: "1px solid #f0f0f0",
+            borderRadius: "8px",
+            boxShadow: "0px 4px 10px rgba(0, 0, 0, 0.1)",
           }}
         >
-          <Button
-            variant={inputs.isFaithful === true ? "contained" : "outlined"}
-            color="primary"
-            onClick={() => handleInputChange("isFaithful", true)}
-          >
-            True
-          </Button>
-          <Button
-            variant={inputs.isFaithful === false ? "contained" : "outlined"}
-            color="primary"
-            onClick={() => handleInputChange("isFaithful", false)}
-          >
-            False
-          </Button>
-        </Box>
-
-        {/* True/False Buttons for Relevance */}
-        <Typography variant="body1" sx={{ marginBottom: "10px" }}>
-          Do you think the response is relevant?
-        </Typography>
-        <Box
-          sx={{
-            display: "flex",
-            justifyContent: "center", // Center buttons
-            gap: "10px",
-            marginBottom: "20px",
-          }}
-        >
-          <Button
-            variant={inputs.isRelevant === true ? "contained" : "outlined"}
-            color="primary"
-            onClick={() => handleInputChange("isRelevant", true)}
-          >
-            True
-          </Button>
-          <Button
-            variant={inputs.isRelevant === false ? "contained" : "outlined"}
-            color="primary"
-            onClick={() => handleInputChange("isRelevant", false)}
-          >
-            False
-          </Button>
-        </Box>
-
-        {/* Faithfulness Input */}
-        <Box sx={{ marginBottom: "20px" }}>
-          <TextField
-            label="Reasoning for Faithfulness Rating"
-            placeholder="Copy-paste the piece of text from the response that supports your faithfulness rating"
-            multiline
-            rows={4}
-            fullWidth
-            variant="outlined"
-            value={inputs.faithfulness}
-            onChange={(e) => handleInputChange("faithfulness", e.target.value)}
-          />
-        </Box>
-
-        {/* Relevance Input */}
-        <Box sx={{ marginBottom: "20px" }}>
-          <TextField
-            label="Reasoning for Relevance Rating"
-            placeholder="Copy-paste the piece of text from the response that supports your relevance rating"
-            multiline
-            rows={4}
-            fullWidth
-            variant="outlined"
-            value={inputs.relevance}
-            onChange={(e) => handleInputChange("relevance", e.target.value)}
-          />
-        </Box>
-
-        {/* Comments Input */}
-        <Box sx={{ marginBottom: "20px" }}>
-          <TextField
-            label="Comments (optional)"
-            multiline
-            rows={5}
-            fullWidth
-            variant="outlined"
-            value={inputs.comments}
-            onChange={(e) => handleInputChange("comments", e.target.value)}
-          />
-        </Box>
-
-        {/* Buttons */}
-        <Box sx={{ display: "flex", flexDirection: "column", gap: "10px" }}>
-          <Button variant="contained" color="primary" onClick={handleSkip}>
-            Skip Task
-          </Button>
-          <Button variant="contained" color="primary" onClick={handleSubmit}>
-            Submit Task
-          </Button>
-        </Box>
-
-        {/* Progress Bar */}
-        <Box sx={{ marginTop: "25px" }}>
-          <Typography variant="body2" sx={{ marginBottom: "5px" }}>
-            Progress: {currentIndex + 1} / {questions.length}
+          <div>
+          <Typography variant="h6" sx={{ fontWeight: "bold", marginBottom: "5px", textAlign:"center" }}>
+            Task Evaluation
           </Typography>
-          <LinearProgress variant="determinate" value={progress} sx={{ height: "5px" }} />
-        </Box>
-
-        {showError && (
-          <Typography color="error" sx={{ marginTop: "2px" }}>
-            Please complete all fields before submitting.
+          </div>
+          {/* Faithfulness Section */}
+          <div>
+          <Typography variant="body1" sx={{ marginBottom: "4px" }}>
+            Do you think the response is faithful?
           </Typography>
-        )}
-      </Box>
-    </Container>
+          <Box sx={{ display: "flex", justifyContent: "center", gap: "4px", marginBottom: "10px" }}>
+            <Button
+              variant={inputs.isFaithful === true ? "contained" : "outlined"}
+              color="primary"
+              onClick={() => handleInputChange("isFaithful", true)}
+            >
+              True
+            </Button>
+            <Button
+              variant={inputs.isFaithful === false ? "contained" : "outlined"}
+              color="primary"
+              onClick={() => handleInputChange("isFaithful", false)}
+            >
+              False
+            </Button>
+          </Box>
+          </div>
+          {/* Relevance Section */}
+          <div>
+          <Typography variant="body1" sx={{ marginBottom: "4px" }}>
+            Do you think the response is relevant?
+          </Typography>
+          <Box sx={{ display: "flex", justifyContent: "center", gap: "4px", marginBottom: "15px" }}>
+            <Button
+              variant={inputs.isRelevant === true ? "contained" : "outlined"}
+              color="primary"
+              onClick={() => handleInputChange("isRelevant", true)}
+            >
+              True
+            </Button>
+            <Button
+              variant={inputs.isRelevant === false ? "contained" : "outlined"}
+              color="primary"
+              onClick={() => handleInputChange("isRelevant", false)}
+            >
+              False
+            </Button>
+          </Box>
+          </div>
+          {/* Faithfulness Input */}
+          <div>
+          <Box sx={{ marginBottom: "10px" }}>
+            <TextField
+              label="Reasoning for Faithfulness Rating"
+              placeholder="Copy-paste the piece of text from the response that supports your faithfulness rating"
+              multiline
+              rows={4}
+              fullWidth
+              variant="outlined"
+              value={inputs.faithfulness}
+              onChange={(e) => handleInputChange("faithfulness", e.target.value)}
+              InputProps={{
+                style: {
+                  padding: "12px", // Adjust padding
+                },
+              }}
+            />
+          </Box>
+          </div>
+          {/* Relevance Input */}
+          <div>
+          <Box sx={{ marginBottom: "10px" }}>
+            <TextField
+              label="Reasoning for Relevance Rating"
+              placeholder="Copy-paste the piece of text from the response that supports your relevance rating"
+              multiline
+              rows={4}
+              fullWidth
+              variant="outlined"
+              value={inputs.relevance}
+              onChange={(e) => handleInputChange("relevance", e.target.value)}
+              InputProps={{
+                style: {
+                  padding: "12px", // Adjust padding
+                },
+              }}
+            />
+          </Box>
+          </div>
+          {/* Comments Input */}
+          <div>
+          <Box sx={{ marginBottom: "10px" }}>
+            <TextField
+              label="Comments (optional)"
+              multiline
+              rows={5}
+              fullWidth
+              variant="outlined"
+              value={inputs.comments}
+              onChange={(e) => handleInputChange("comments", e.target.value)}
+              InputProps={{
+                style: {
+                  padding: "12px", // Adjust padding
+                },
+              }}
+            />
+          </Box>
+          </div>
+          {/* Buttons */}
+          <div>
+          <Box sx={{ display: "flex", flexDirection: "column", gap: "5px" }}>
+            <Button variant="contained" color="primary" onClick={handleSkip}>
+              Skip Task
+            </Button>
+            <Button variant="contained" color="primary" onClick={handleSubmit}>
+              Submit Task
+            </Button>
+          </Box>
+          </div>
+          {/* Progress */}
+          <div>
+          <Box sx={{ marginTop: "10px" }}>
+            <Typography variant="body2" sx={{ marginBottom: "2px" }}>
+              Progress: {currentIndex + 1} / {questions.length}
+            </Typography>
+            <LinearProgress variant="determinate" value={progress} sx={{ height: "8px" }} />
+          </Box>
+          </div>
+          <div>
+          {showError && (
+            <Typography color="error" sx={{ marginTop: "2px" }}>
+              Please complete all fields before submitting.
+            </Typography>
+          )} 
+          </div>
+        </Box>
+    </div>
+    <div class="content">
+    <QuestionPanel
+        query={questions[currentIndex].query}
+        context={questions[currentIndex].context}
+        response={questions[currentIndex].response}
+    />
+    </div>
+</body>
   );
 };
 

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,15 +1,19 @@
 import React, { useState, useEffect } from "react";
 import QuestionPanel from "./QuestionPanel";
 import { Container, Typography, Button, Box, LinearProgress, TextField } from "@mui/material";
-import questionsData from "./tasks.json"; // Import the JSON file
+import questionsData from "./tasks.json";
 
 const App = () => {
   const [questions, setQuestions] = useState([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [taskAnswers, setTaskAnswers] = useState([]);
-  const [faithfulness, setFaithfulness] = useState(undefined);
-  const [relevance, setRelevance] = useState(undefined);
-  const [comments, setComments] = useState("");
+  const [inputs, setInputs] = useState({
+    faithfulness: "",
+    relevance: "",
+    comments: "",
+    isFaithful: null,
+    isRelevant: null,
+  });
   const [showError, setShowError] = useState(false);
 
   useEffect(() => {
@@ -17,41 +21,35 @@ const App = () => {
     setQuestions(shuffledQuestions);
   }, []);
 
+  const handleInputChange = (field, value) => {
+    setInputs((prev) => ({ ...prev, [field]: value }));
+  };
+
   const handleNext = () => {
     setCurrentIndex(currentIndex + 1);
   };
 
   const resetFields = () => {
-    setFaithfulness(undefined);
-    setRelevance(undefined);
-    setComments("");
+    setInputs({
+      faithfulness: "",
+      relevance: "",
+      comments: "",
+      isFaithful: null,
+      isRelevant: null,
+    });
     setShowError(false);
   };
 
-  const handleFaithfulnessChange = (value) => {
-    setFaithfulness(value);
-    if (value !== undefined && relevance !== undefined) {
-      setShowError(false);
-    }
-  };
-
-  const handleRelevanceChange = (value) => {
-    setRelevance(value);
-    if (faithfulness !== undefined && value !== undefined) {
-      setShowError(false);
-    }
-  };
-
   const handleSubmit = () => {
-    if (faithfulness === undefined || relevance === undefined) {
+    const { faithfulness, relevance, isFaithful, isRelevant } = inputs;
+    if (!faithfulness.trim() || !relevance.trim() || isFaithful === null || isRelevant === null) {
       setShowError(true);
       return;
     }
+
     const evaluation = {
       questionId: questions[currentIndex].id,
-      faithfulness,
-      relevance,
-      comments,
+      ...inputs,
     };
     setTaskAnswers((prev) => [...prev, evaluation]);
     resetFields();
@@ -81,19 +79,22 @@ const App = () => {
 
   if (currentIndex >= questions.length) {
     return (
-      <Container maxWidth="md">
-        <Box sx={{ textAlign: 'center', marginTop: '48px' }}>
-          <Typography variant="h4" sx={{ marginBottom: '24px' }}>
-            Thank you for completing the survey!
-          </Typography>
-          <Button 
-            variant="contained" 
-            color="primary"
-            onClick={downloadAnswers}
-          >
-            Download Responses
-          </Button>
-        </Box>
+      <Container
+        maxWidth="md"
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          alignItems: "center",
+          height: "100vh",
+        }}
+      >
+        <Typography variant="h4" sx={{ marginBottom: "3vh" }}>
+          Thank you for completing the survey!
+        </Typography>
+        <Button variant="contained" color="primary" onClick={downloadAnswers}>
+          Download Responses
+        </Button>
       </Container>
     );
   }
@@ -101,134 +102,162 @@ const App = () => {
   const progress = ((currentIndex + 1) / questions.length) * 100;
 
   return (
-    <Container maxWidth="md">
-      {/* Fixed Header */}
-      <Box
-        sx={{
-          position: "fixed",
-          top: 0,
-          left: 0,
-          width: "100%",
-          backgroundColor: "#fff",
-          zIndex: 1000,
-          borderBottom: "1px solid #ddd",
-          padding: "8px",
-          boxSizing: "border-box",
-        }}
-      >
-        {/* Task Evaluation Section */}
-        <Box
-          sx={{
-            display: "flex",
-            alignItems: "flex-start",
-            marginLeft: "10%",
-            marginRight: "10%",
-          }}
-        >
-          {/* Faithfulness and Relevance Buttons arranged horizontally */}
-          <Box sx={{ display: "flex", flexDirection: "column", marginRight: "8px" }}>
-            <Box sx={{ display: "flex", alignItems: "center", marginBottom: "4px" }}>
-              <Typography sx={{ marginRight: "4px" }}>Faithfulness:</Typography>
-              <Button
-                variant={faithfulness === 1 ? "contained" : "outlined"}
-                onClick={() => handleFaithfulnessChange(1)}
-                sx={{ marginRight: "4px" }}
-              >
-                True
-              </Button>
-              <Button
-                variant={faithfulness === 0 ? "contained" : "outlined"}
-                onClick={() => handleFaithfulnessChange(0)}
-              >
-                False
-              </Button>
-            </Box>
-            <Box sx={{ display: "flex", alignItems: "center" }}>
-              <Typography sx={{ marginRight: "4px" }}>Relevance:</Typography>
-              <Button
-                variant={relevance === 1 ? "contained" : "outlined"}
-                onClick={() => handleRelevanceChange(1)}
-                sx={{ marginRight: "4px" }}
-              >
-                True
-              </Button>
-              <Button
-                variant={relevance === 0 ? "contained" : "outlined"}
-                onClick={() => handleRelevanceChange(0)}
-              >
-                False
-              </Button>
-            </Box>
-          </Box>
-
-          {/* Comments Field filling remaining vertical space */}
-          <Box sx={{ flexGrow: 1, marginRight: "8px" }}>
-            <TextField
-              label="Comments (optional)"
-              multiline
-              rows={2}
-              fullWidth
-              variant="outlined"
-              value={comments}
-              onChange={(e) => setComments(e.target.value)}
-            />
-          </Box>
-
-          {/* Skip and Submit Buttons Stacked Vertically */}
-          <Box sx={{ display: "flex", flexDirection: "column" }}>
-            <Button
-              variant="contained"
-              color="primary"
-              onClick={handleSkip}
-              sx={{ marginBottom: "4px" }}
-            >
-              Skip Task
-            </Button>
-            <Button
-              variant="contained"
-              color="primary"
-              onClick={handleSubmit}
-            >
-              Submit Task
-            </Button>
-          </Box>
-        </Box>
-
-        {/* Progress Bar with Numerical Counter */}
-        <Box
-          sx={{
-            display: "flex",
-            alignItems: "center",
-            marginTop: "8px",
-            marginLeft: "10%",
-            marginRight: "10%",
-          }}
-        >
-          <Typography variant="body2" sx={{ marginRight: "8px" }}>
-            {currentIndex + 1} / {questions.length}
-          </Typography>
-          <Box sx={{ flexGrow: 1 }}>
-            <LinearProgress variant="determinate" value={progress} sx={{ height: 8 }} />
-          </Box>
-        </Box>
-
-        {/* Error Message */}
-        {showError && (
-          <Box display="flex" justifyContent="center" alignItems="center">
-            <Typography color="error" sx={{ mt: 1 }}>
-              Please select both faithfulness and relevance before submitting
-            </Typography>
-          </Box>
-        )}
-      </Box>
-
-      {/* Main Content */}
-      <Box>
+    <Container
+      maxWidth="lg"
+      sx={{ display: "flex", flexDirection: "column", alignItems: "center", height: "100vh" }}
+    >
+      {/* Centered Question Panel */}
+      <Box sx={{ width: "75%", marginBottom: "5vh" }}>
         <QuestionPanel
           query={questions[currentIndex].query}
           context={questions[currentIndex].context}
           response={questions[currentIndex].response}
         />
+      </Box>
+
+      {/* Task Evaluation Box */}
+      <Box
+        sx={{
+          position: "fixed",
+          // top: "50%",
+          right: "0%",
+          // transform: "translateY(-50%)",
+          width: "25%",
+          backgroundColor: "#ffffff",
+          border: "0.5vh solid #f9f9f9",
+          borderRadius: "1px",
+          // backgroundColor: "#f9f9f9",
+          padding: "2vh",
+          boxSizing: "border-box",
+          boxShadow: "0px 1px 2px rgba(0, 0, 0, 0.1)",
+          margin: "0px",
+          textAlign: "center", // Center title and content
+        }}
+      >
+        <Typography variant="h6" sx={{ fontWeight: "bold", marginBottom: "2vh" }}>
+          Task Evaluation
+        </Typography>
+
+        {/* True/False Buttons for Faithfulness */}
+        <Typography variant="body1" sx={{ marginBottom: "10px" }}>
+          Do you think the response is faithful?
+        </Typography>
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "center", // Center buttons
+            gap: "10px",
+            marginBottom: "10px",
+          }}
+        >
+          <Button
+            variant={inputs.isFaithful === true ? "contained" : "outlined"}
+            color="primary"
+            onClick={() => handleInputChange("isFaithful", true)}
+          >
+            True
+          </Button>
+          <Button
+            variant={inputs.isFaithful === false ? "contained" : "outlined"}
+            color="primary"
+            onClick={() => handleInputChange("isFaithful", false)}
+          >
+            False
+          </Button>
+        </Box>
+
+        {/* True/False Buttons for Relevance */}
+        <Typography variant="body1" sx={{ marginBottom: "10px" }}>
+          Do you think the response is relevant?
+        </Typography>
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "center", // Center buttons
+            gap: "10px",
+            marginBottom: "20px",
+          }}
+        >
+          <Button
+            variant={inputs.isRelevant === true ? "contained" : "outlined"}
+            color="primary"
+            onClick={() => handleInputChange("isRelevant", true)}
+          >
+            True
+          </Button>
+          <Button
+            variant={inputs.isRelevant === false ? "contained" : "outlined"}
+            color="primary"
+            onClick={() => handleInputChange("isRelevant", false)}
+          >
+            False
+          </Button>
+        </Box>
+
+        {/* Faithfulness Input */}
+        <Box sx={{ marginBottom: "20px" }}>
+          <TextField
+            label="Reasoning for Faithfulness Rating"
+            placeholder="Copy-paste the piece of text from the response that supports your faithfulness rating"
+            multiline
+            rows={4}
+            fullWidth
+            variant="outlined"
+            value={inputs.faithfulness}
+            onChange={(e) => handleInputChange("faithfulness", e.target.value)}
+          />
+        </Box>
+
+        {/* Relevance Input */}
+        <Box sx={{ marginBottom: "20px" }}>
+          <TextField
+            label="Reasoning for Relevance Rating"
+            placeholder="Copy-paste the piece of text from the response that supports your relevance rating"
+            multiline
+            rows={4}
+            fullWidth
+            variant="outlined"
+            value={inputs.relevance}
+            onChange={(e) => handleInputChange("relevance", e.target.value)}
+          />
+        </Box>
+
+        {/* Comments Input */}
+        <Box sx={{ marginBottom: "20px" }}>
+          <TextField
+            label="Comments (optional)"
+            multiline
+            rows={5}
+            fullWidth
+            variant="outlined"
+            value={inputs.comments}
+            onChange={(e) => handleInputChange("comments", e.target.value)}
+          />
+        </Box>
+
+        {/* Buttons */}
+        <Box sx={{ display: "flex", flexDirection: "column", gap: "10px" }}>
+          <Button variant="contained" color="primary" onClick={handleSkip}>
+            Skip Task
+          </Button>
+          <Button variant="contained" color="primary" onClick={handleSubmit}>
+            Submit Task
+          </Button>
+        </Box>
+
+        {/* Progress Bar */}
+        <Box sx={{ marginTop: "25px" }}>
+          <Typography variant="body2" sx={{ marginBottom: "5px" }}>
+            Progress: {currentIndex + 1} / {questions.length}
+          </Typography>
+          <LinearProgress variant="determinate" value={progress} sx={{ height: "5px" }} />
+        </Box>
+
+        {showError && (
+          <Typography color="error" sx={{ marginTop: "2px" }}>
+            Please complete all fields before submitting.
+          </Typography>
+        )}
       </Box>
     </Container>
   );

--- a/client/src/QuestionPanel.js
+++ b/client/src/QuestionPanel.js
@@ -6,20 +6,19 @@ const QuestionPanel = ({ query, context, response }) => {
   return (
     <Box
       sx={{
-        padding: "16px",
+        padding: "2%",
         backgroundColor: "#f9f9f9",
-        // Reduce the top margin to account for the fixed header height
-        marginTop: "120px",
+        width: "100%",
       }}
     >
       {/* Query Section */}
       <Box
         sx={{
           backgroundColor: "#ffffff",
-          padding: "16px",
-          borderRadius: "8px",
-          marginBottom: "16px",
-          border: "1px solid #ddd"
+          padding: "2%",
+          borderRadius: "1vh",
+          marginBottom: "2%",
+          border: "0.2vh solid #ddd",
         }}
       >
         <Typography variant="h6" sx={{ fontWeight: "bold", color: "#333" }}>
@@ -34,10 +33,10 @@ const QuestionPanel = ({ query, context, response }) => {
       <Box
         sx={{
           backgroundColor: "#e8f5e9", // Light green for context
-          padding: "16px",
-          borderRadius: "8px",
-          marginBottom: "16px",
-          border: "1px solid #ddd"
+          padding: "2%",
+          borderRadius: "1vh",
+          marginBottom: "2%",
+          border: "0.2vh solid #ddd",
         }}
       >
         <Typography variant="h6" sx={{ fontWeight: "bold", color: "#2e7d32" }}>
@@ -50,10 +49,10 @@ const QuestionPanel = ({ query, context, response }) => {
       <Box
         sx={{
           backgroundColor: "#e3f2fd", // Light blue for response
-          padding: "16px",
-          borderRadius: "8px",
-          marginBottom: "16px",
-          border: "1px solid #ddd"
+          padding: "2%",
+          borderRadius: "1vh",
+          marginBottom: "2%",
+          border: "0.2vh solid #ddd",
         }}
       >
         <Typography variant="h6" sx={{ fontWeight: "bold", color: "#1565c0" }}>

--- a/client/src/QuestionPanel.js
+++ b/client/src/QuestionPanel.js
@@ -6,9 +6,8 @@ const QuestionPanel = ({ query, context, response }) => {
   return (
     <Box
       sx={{
-        padding: "2%",
+        padding: "2px",
         backgroundColor: "#f9f9f9",
-        width: "100%",
       }}
     >
       {/* Query Section */}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/507c5098-9f52-41f4-876e-6d44e0c916c7)


I moved the selection bar to the side per group feedback and added copy/paste boxes for users to specify their reasoning. Highlighting was too annoying to implement based on the scope of the project. Now they have to fill in both the true/false and reasoning to advance to next question, unless skipped.